### PR TITLE
🔧 Fix import paths in useTransactionHistory (TOKEN_SWAP_CONFIG, COURSE_CONTRACT_CONFIG)

### DIFF
--- a/src/hooks/useTransactionHistory.ts
+++ b/src/hooks/useTransactionHistory.ts
@@ -1,26 +1,8 @@
 import { useState, useCallback, useEffect } from 'react';
 import { useAccount, usePublicClient } from 'wagmi';
 import { formatEther } from 'viem';
-import { TOKEN_SWAP_CONFIG, COURSE_CONTRACT_CONFIG } from '../config/contract';
-
-// 移除未使用的枚举
-// export enum TransactionType {
-//   COURSE_PURCHASE = 'COURSE_PURCHASE',
-//   TOKEN_SWAP = 'TOKEN_SWAP',
-//   REWARD_CLAIM = 'REWARD_CLAIM',
-// }
-
-// export enum TransactionStatus {
-//   PENDING = 'PENDING',
-//   SUCCESS = 'SUCCESS',
-//   FAILED = 'FAILED',
-// }
-
-// 移除未使用的常量
-// const TOKEN_SWAP_EVENTS = [
-//   'ETHSwappedForYD',
-//   'YDSwappedForETH',
-// ] as const;
+import { TOKEN_SWAP_CONFIG } from '../config/tokenSwap';
+import { COURSE_CONTRACT_CONFIG } from '../config/courseContract';
 
 export interface TransactionRecord {
   hash: string;
@@ -73,8 +55,6 @@ export const useTransactionHistory = (): UseTransactionHistoryResult => {
         for (const log of swapLogs) {
           try {
             const block = await publicClient.getBlock({ blockNumber: log.blockNumber });
-            // 移除未使用的变量
-            // const transaction = await publicClient.getTransaction({ hash: log.transactionHash });
             
             allTransactions.push({
               hash: log.transactionHash,
@@ -105,8 +85,6 @@ export const useTransactionHistory = (): UseTransactionHistoryResult => {
         for (const log of courseLogs) {
           try {
             const block = await publicClient.getBlock({ blockNumber: log.blockNumber });
-            // 移除未使用的变量
-            // const transaction = await publicClient.getTransaction({ hash: log.transactionHash });
             
             allTransactions.push({
               hash: log.transactionHash,


### PR DESCRIPTION
## 🔧 Fix Import Paths in useTransactionHistory

This PR fixes the critical import error where `useTransactionHistory.ts` was trying to import configuration objects from the wrong modules.

### 🐛 Problem Fixed

**Error**: `Uncaught SyntaxError: The requested module '/src/config/contract.ts' does not provide an export named 'COURSE_CONTRACT_CONFIG'`

**Root Cause**: 
- `useTransactionHistory.ts` was importing both `TOKEN_SWAP_CONFIG` and `COURSE_CONTRACT_CONFIG` from `../config/contract.ts`
- `TOKEN_SWAP_CONFIG` is actually exported from `../config/tokenSwap.ts`
- `COURSE_CONTRACT_CONFIG` is actually exported from `../config/courseContract.ts`
- The `contract.ts` file only contains basic contract ABI and general configuration

### 🛠️ Solutions Implemented

#### **Fixed Import Paths**
```typescript
// ❌ Before (incorrect imports)
import { TOKEN_SWAP_CONFIG, COURSE_CONTRACT_CONFIG } from '../config/contract';

// ✅ After (correct imports)
import { TOKEN_SWAP_CONFIG } from '../config/tokenSwap';
import { COURSE_CONTRACT_CONFIG } from '../config/courseContract';
```

#### **Code Cleanup**
- ✅ Removed commented-out unused enums and constants
- ✅ Cleaned up unused variable assignments
- ✅ Maintained all existing functionality
- ✅ Improved code readability

### 📋 Import Structure Overview

| Configuration | Correct Module | Purpose |
|---------------|----------------|---------|
| `TOKEN_SWAP_CONFIG` | `config/tokenSwap.ts` | Token exchange configuration |
| `COURSE_CONTRACT_CONFIG` | `config/courseContract.ts` | Course management configuration |
| `WEB3_SCHOOL_CONTRACT_ABI` | `config/contract.ts` | General contract ABI |

### 🎯 Key Changes

1. **Correct Import Sources**: Each configuration is now imported from its proper module
2. **Maintained Functionality**: All transaction history features remain intact
3. **Better Code Organization**: Imports now follow the logical module structure

### 🚀 Benefits

- ✅ **Fixes Runtime Error**: Resolves the critical SyntaxError blocking transaction history
- ✅ **Proper Module Structure**: Imports align with actual export locations
- ✅ **Code Clarity**: Cleaner, more organized import statements
- ✅ **Maintainability**: Easier to understand module dependencies

### 🧪 Testing

- ✅ Import paths now resolve correctly
- ✅ Transaction history hook initializes without errors
- ✅ All existing functionality preserved
- ✅ No breaking changes to the public API

### 📚 Module Dependencies

```
useTransactionHistory.ts
├── config/tokenSwap.ts (TOKEN_SWAP_CONFIG)
│   └── Token swap contract address & ABI
└── config/courseContract.ts (COURSE_CONTRACT_CONFIG)  
    └── Course contract address & ABI
```

This resolves the blocking import error and enables the transaction history functionality!