### PR TITLE
feat: 添加AAVE USDT余额调试功能

### DIFF
--- a/src/pages/TokenSwap/components/AaveStaking.tsx
+++ b/src/pages/TokenSwap/components/AaveStaking.tsx
@@ -11,6 +11,7 @@ import {
   CheckCircle,
   RefreshCw,
   Info,
+  Bug,
 } from 'lucide-react';
 import { useAave } from '../../../hooks/useAave';
 import { useWeb3 } from '../../../contexts/Web3Context';
@@ -41,12 +42,14 @@ const AaveStaking: React.FC<AaveStakingProps> = ({ onRefresh }) => {
     refetchAll,
     calculateExpectedReturn,
     formatNumber,
+    debugUsdtBalance, // 添加调试函数
   } = useAave();
 
   const [activeTab, setActiveTab] = useState<'stake' | 'withdraw'>('stake');
   const [stakeAmount, setStakeAmount] = useState('');
   const [withdrawAmount, setWithdrawAmount] = useState('');
   const [showAdvanced, setShowAdvanced] = useState(false);
+  const [showDebug, setShowDebug] = useState(false); // 新增调试面板状态
 
   // 重置表单
   const resetForm = () => {
@@ -70,6 +73,16 @@ const AaveStaking: React.FC<AaveStakingProps> = ({ onRefresh }) => {
       setStakeAmount(parseFloat(usdtBalance).toFixed(6));
     } else {
       setWithdrawAmount(parseFloat(aUsdtBalance).toFixed(6));
+    }
+  };
+
+  // 处理调试按钮点击
+  const handleDebugClick = async () => {
+    console.log('🐛 开始调试USDT余额...');
+    if (debugUsdtBalance) {
+      await debugUsdtBalance();
+    } else {
+      console.error('❌ debugUsdtBalance 函数不可用');
     }
   };
 
@@ -174,7 +187,7 @@ const AaveStaking: React.FC<AaveStakingProps> = ({ onRefresh }) => {
 
   return (
     <div className="bg-white rounded-xl shadow-lg p-6 mb-6">
-      {/* 标题和刷新按钮 */}
+      {/* 标题和控制按钮 */}
       <div className="flex items-center justify-between mb-6">
         <div className="flex items-center space-x-3">
           <Shield className="h-6 w-6 text-green-600" />
@@ -183,16 +196,82 @@ const AaveStaking: React.FC<AaveStakingProps> = ({ onRefresh }) => {
             {aaveConfig?.name}
           </div>
         </div>
+        <div className="flex items-center space-x-2">
+          {/* 调试按钮 */}
+          <button
+            onClick={handleDebugClick}
+            className="p-2 text-gray-500 hover:text-red-600 transition-colors"
+            title="调试USDT余额获取"
+          >
+            <Bug className="h-5 w-5" />
+          </button>
+          {/* 刷新按钮 */}
+          <button
+            onClick={() => {
+              refetchAll();
+              if (onRefresh) onRefresh();
+            }}
+            className="p-2 text-gray-500 hover:text-green-600 transition-colors"
+            title="刷新AAVE数据"
+          >
+            <RefreshCw className={`h-5 w-5 ${isLoading ? 'animate-spin' : ''}`} />
+          </button>
+        </div>
+      </div>
+
+      {/* 调试信息面板 */}
+      <div className="mb-6">
         <button
-          onClick={() => {
-            refetchAll();
-            if (onRefresh) onRefresh();
-          }}
-          className="p-2 text-gray-500 hover:text-green-600 transition-colors"
-          title="刷新AAVE数据"
+          onClick={() => setShowDebug(!showDebug)}
+          className="text-sm text-gray-600 hover:text-gray-800 mb-2 flex items-center space-x-1"
         >
-          <RefreshCw className={`h-5 w-5 ${isLoading ? 'animate-spin' : ''}`} />
+          <Bug className="h-4 w-4" />
+          <span>调试信息</span>
+          <span>{showDebug ? '▲' : '▼'}</span>
         </button>
+
+        {showDebug && (
+          <div className="bg-red-50 border border-red-200 rounded-lg p-4 space-y-3">
+            <div className="text-sm">
+              <h4 className="font-semibold text-red-800 mb-2">USDT余额调试</h4>
+              <div className="grid grid-cols-2 gap-4 text-xs">
+                <div>
+                  <span className="text-gray-600">当前USDT余额:</span>
+                  <p className="font-mono bg-white px-2 py-1 rounded">{usdtBalance || '获取中...'}</p>
+                </div>
+                <div>
+                  <span className="text-gray-600">网络支持状态:</span>
+                  <p className={`font-mono px-2 py-1 rounded ${isNetworkSupported ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'}`}>
+                    {isNetworkSupported ? '✅ 支持' : '❌ 不支持'}
+                  </p>
+                </div>
+                <div>
+                  <span className="text-gray-600">USDT合约地址:</span>
+                  <p className="font-mono bg-white px-2 py-1 rounded text-xs break-all">
+                    {aaveConfig?.usdtAddress || '未获取'}
+                  </p>
+                </div>
+                <div>
+                  <span className="text-gray-600">链ID:</span>
+                  <p className="font-mono bg-white px-2 py-1 rounded">
+                    {aaveConfig?.chainId || '未获取'}
+                  </p>
+                </div>
+              </div>
+              <div className="mt-3">
+                <button
+                  onClick={handleDebugClick}
+                  className="px-3 py-1 bg-red-600 text-white text-xs rounded hover:bg-red-700 transition-colors"
+                >
+                  运行余额调试
+                </button>
+                <p className="text-xs text-red-600 mt-1">
+                  点击按钮查看控制台详细调试信息
+                </p>
+              </div>
+            </div>
+          </div>
+        )}
       </div>
 
       {/* 余额信息 */}
@@ -205,6 +284,9 @@ const AaveStaking: React.FC<AaveStakingProps> = ({ onRefresh }) => {
           <p className="text-lg font-bold text-blue-600">
             {formatNumber(usdtBalance)} USDT
           </p>
+          {usdtBalance === '0' && (
+            <p className="text-xs text-red-500 mt-1">⚠️ 余额为0，请检查</p>
+          )}
         </div>
 
         <div className="bg-green-50 rounded-lg p-4">


### PR DESCRIPTION
## 🐛 问题描述
用户反馈AAVE部分的USDT余额无法获取，虽然在"我的账户余额"中能正常显示USDT。

## 🔧 解决方案
添加详细的调试功能，帮助诊断USDT余额获取问题：

### 新增功能
1. **调试按钮** - 在AAVE界面添加专门的调试按钮（虫子图标）
2. **调试面板** - 展开式调试信息面板，显示关键状态
3. **调试函数集成** - 集成useAave中的debugUsdtBalance函数
4. **状态监控** - 实时显示余额获取状态和配置信息

### 调试功能详情
- 🐛 **一键调试** - 点击调试按钮触发详细的余额获取分析
- 📊 **状态显示** - 显示当前USDT余额、网络支持状态、合约地址、链ID
- ⚠️ **异常提示** - 当余额为0时显示警告提示
- 📝 **控制台日志** - 输出详细的调试信息到控制台

### 用户体验改进
- 界面保持简洁，调试面板默认折叠
- 调试按钮位于标题栏右侧，易于访问
- 调试信息以红色主题突出显示
- 提供操作指引和说明

## 🧪 使用方法
1. 打开AAVE理财界面
2. 点击标题栏的虫子图标进行调试
3. 或展开"调试信息"面板查看状态
4. 查看控制台日志获取详细信息

## 📋 预期效果
这个调试功能将帮助：
- 快速定位USDT余额获取失败的原因
- 验证网络配置和合约地址
- 提供详细的错误信息和解决建议
- 改善开发和用户体验

## 🔍 技术实现
- 复用useAave中的debugUsdtBalance函数
- 添加状态监控和可视化显示
- 优化错误处理和用户反馈
- 保持代码结构清晰和维护性